### PR TITLE
fix(fetchers): allow non-strict bank SSL chains

### DIFF
--- a/src/twrate/fetchers/_ssl.py
+++ b/src/twrate/fetchers/_ssl.py
@@ -1,0 +1,20 @@
+"""SSL helpers for bank endpoints with non-standard certificate chains."""
+
+import ssl
+
+import httpx
+
+
+def create_bank_ssl_context() -> ssl.SSLContext:
+    """Create an SSL context that keeps verification but relaxes OpenSSL strict mode.
+
+    Some Taiwanese bank endpoints currently serve certificate chains that fail
+    OpenSSL's strict RFC 5280 checks with ``Missing Subject Key Identifier``.
+    Clearing ``VERIFY_X509_STRICT`` preserves CA and hostname verification while
+    avoiding a full ``verify=False`` bypass.
+    """
+    context = httpx.create_ssl_context()
+    strict_flag = getattr(ssl, "VERIFY_X509_STRICT", 0)
+    if strict_flag:
+        context.verify_flags &= ~strict_flag
+    return context

--- a/src/twrate/fetchers/cathay.py
+++ b/src/twrate/fetchers/cathay.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 
 from ..types import Exchange
 from ..types import Rate
+from ._ssl import create_bank_ssl_context
 
 
 def parse_rate(value: str) -> float | None:
@@ -93,7 +94,7 @@ async def fetch_cathay_rates() -> list[Rate]:
     """
     url = "https://www.cathaybk.com.tw/cathaybk/personal/product/deposit/currency-billboard/"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=create_bank_ssl_context()) as client:
         resp = await client.get(url, follow_redirects=True, timeout=30)
         resp.raise_for_status()
 

--- a/src/twrate/fetchers/nextbank.py
+++ b/src/twrate/fetchers/nextbank.py
@@ -2,6 +2,7 @@ import httpx
 
 from ..types import Exchange
 from ..types import Rate
+from ._ssl import create_bank_ssl_context
 
 
 def parse_rate(value: str) -> float | None:
@@ -26,7 +27,7 @@ async def fetch_nextbank_rates() -> list[Rate]:
 
     api_url = "https://api.nextbank.com.tw/ap6/open/forex/v1.0/GetFXRate"
 
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=create_bank_ssl_context()) as client:
         resp = await client.post(api_url, json={}, follow_redirects=True)
         resp.raise_for_status()
 


### PR DESCRIPTION
## Summary
- add a shared SSL context helper that clears OpenSSL strict verification only
- apply it to Next Bank and Cathay fetchers so their certificate chains still pass CA and hostname verification
- avoid adding curl_cffi for this fix

## Tests
- uv run pytest
- uv run twrate USD