### PR TITLE
feat: add more Taiwanese bank fetchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,10 @@ uv run pytest -v -s --cov=src tests
 Support for additional Taiwanese banks:
 
 - [ ] 台新銀行 (Taishin Bank) - https://www.taishinbank.com.tw/TSB/personal/deposit/lookup/realtime/
+- [ ] 兆豐銀行 (Mega International Commercial Bank) - https://www.megabank.com.tw/personal/savings/foreign-service/forex
+- [ ] 第一銀行 (First Bank) - https://www.firstbank.com.tw/sites/fcb/touch/1565688252532
+- [ ] 土地銀行 (Land Bank) - https://rate.landbank.com.tw/zh-TW/Foreign?mid=35
+- [ ] 元大銀行 (Yuanta Bank) - https://www.yuantabank.com.tw/bank/exchangeRate/hostccy.do
+- [ ] 台中銀行 (Taichung Bank) - https://rate.tcbbank.com.tw/CB501014.html
+- [ ] 合作金庫 (Co-operative Bank) - https://www.tcb-bank.com.tw/personal-banking/deposit-exchange/exchange-rate/spot
+- [ ] 台北富邦銀行 (Fubon Bank) - https://www.fubon.com/banking/personal/deposit/exchange_rate/exchange_rate_tw.htm

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A Python package for querying real-time exchange rates from major Taiwanese bank
 - Next Bank (將來銀行)
 - KGI Bank (凱基銀行)
 - Cathay United Bank (國泰世華銀行)
+- Mega International Commercial Bank (兆豐銀行)
+- First Bank (第一銀行)
+- Land Bank (土地銀行)
+- Yuanta Bank (元大銀行)
 
 ## Installation
 
@@ -124,7 +128,7 @@ See the [LICENSE](LICENSE) file for details.
 
 ## Contributing
 
-Contributions are welcome! The package currently supports Bank of Taiwan, DBS Bank, Sinopac Bank, E.SUN Bank, Line Bank, HSBC Bank, Next Bank, KGI Bank, and Cathay United Bank; you can help extend the functionality to cover more Taiwanese banks.
+Contributions are welcome! The package currently supports Bank of Taiwan, DBS Bank, Sinopac Bank, E.SUN Bank, Line Bank, HSBC Bank, Next Bank, KGI Bank, Cathay United Bank, Mega International Commercial Bank, First Bank, Land Bank, and Yuanta Bank; you can help extend the functionality to cover more Taiwanese banks.
 
 ### Development
 
@@ -138,11 +142,11 @@ uv run pytest -v -s --cov=src tests
 
 Support for additional Taiwanese banks:
 
+- [x] 兆豐銀行 (Mega International Commercial Bank) - https://www.megabank.com.tw/personal/savings/foreign-service/forex
+- [x] 第一銀行 (First Bank) - https://www.firstbank.com.tw/sites/fcb/touch/1565688252532
+- [x] 土地銀行 (Land Bank) - https://rate.landbank.com.tw/zh-TW/Foreign?mid=35
+- [x] 元大銀行 (Yuanta Bank) - https://www.yuantabank.com.tw/bank/exchangeRate/hostccy.do
 - [ ] 台新銀行 (Taishin Bank) - https://www.taishinbank.com.tw/TSB/personal/deposit/lookup/realtime/
-- [ ] 兆豐銀行 (Mega International Commercial Bank) - https://www.megabank.com.tw/personal/savings/foreign-service/forex
-- [ ] 第一銀行 (First Bank) - https://www.firstbank.com.tw/sites/fcb/touch/1565688252532
-- [ ] 土地銀行 (Land Bank) - https://rate.landbank.com.tw/zh-TW/Foreign?mid=35
-- [ ] 元大銀行 (Yuanta Bank) - https://www.yuantabank.com.tw/bank/exchangeRate/hostccy.do
 - [ ] 台中銀行 (Taichung Bank) - https://rate.tcbbank.com.tw/CB501014.html
 - [ ] 合作金庫 (Co-operative Bank) - https://www.tcb-bank.com.tw/personal-banking/deposit-exchange/exchange-rate/spot
 - [ ] 台北富邦銀行 (Fubon Bank) - https://www.fubon.com/banking/personal/deposit/exchange_rate/exchange_rate_tw.htm

--- a/src/twrate/fetcher.py
+++ b/src/twrate/fetcher.py
@@ -4,35 +4,41 @@ from .fetchers.bot import fetch_bot_rates
 from .fetchers.cathay import fetch_cathay_rates
 from .fetchers.dbs import fetch_dbs_rates
 from .fetchers.esun import fetch_esun_rates
+from .fetchers.firstbank import fetch_firstbank_rates
 from .fetchers.hsbc import fetch_hsbc_rates
 from .fetchers.kgi import fetch_kgi_rates
+from .fetchers.landbank import fetch_landbank_rates
 from .fetchers.line import fetch_line_rates
+from .fetchers.megabank import fetch_megabank_rates
 from .fetchers.nextbank import fetch_nextbank_rates
 from .fetchers.sinopac import fetch_sinopac_rates
+from .fetchers.yuanta import fetch_yuanta_rates
 from .types import Exchange
 from .types import Rate
 
 
 async def fetch_rates(exchange: Exchange) -> list[Rate]:
     logger.debug("Fetching rates from {:12s}", exchange.name)
-    match exchange:
-        case Exchange.SINOPAC:
-            return await fetch_sinopac_rates()
-        case Exchange.ESUN:
-            return await fetch_esun_rates()
-        case Exchange.LINE:
-            return await fetch_line_rates()
-        case Exchange.BOT:
-            return await fetch_bot_rates()
-        case Exchange.DBS:
-            return await fetch_dbs_rates()
-        case Exchange.HSBC:
-            return await fetch_hsbc_rates()
-        case Exchange.NEXT:
-            return await fetch_nextbank_rates()
-        case Exchange.KGI:
-            return await fetch_kgi_rates()
-        case Exchange.CATHAY:
-            return await fetch_cathay_rates()
-        case _:
-            raise ValueError(f"Unsupported exchange: {exchange}")
+
+    handlers = {
+        Exchange.SINOPAC: fetch_sinopac_rates,
+        Exchange.ESUN: fetch_esun_rates,
+        Exchange.LINE: fetch_line_rates,
+        Exchange.BOT: fetch_bot_rates,
+        Exchange.DBS: fetch_dbs_rates,
+        Exchange.HSBC: fetch_hsbc_rates,
+        Exchange.NEXT: fetch_nextbank_rates,
+        Exchange.KGI: fetch_kgi_rates,
+        Exchange.CATHAY: fetch_cathay_rates,
+        Exchange.MEGABANK: fetch_megabank_rates,
+        Exchange.FIRSTBANK: fetch_firstbank_rates,
+        Exchange.LANDBANK: fetch_landbank_rates,
+        Exchange.YUANTA: fetch_yuanta_rates,
+    }
+
+    fetcher = handlers.get(exchange)
+    if fetcher is None:
+        raise ValueError(f"Unsupported exchange: {exchange}")
+
+    return await fetcher()
+

--- a/src/twrate/fetchers/firstbank.py
+++ b/src/twrate/fetchers/firstbank.py
@@ -1,0 +1,98 @@
+import re
+
+import httpx
+from bs4 import BeautifulSoup
+
+from ..types import Exchange
+from ..types import Rate
+
+_TIMEOUT = 30
+
+
+
+def _parse_rate(value: str | None) -> float | None:
+    """Parse a numeric rate value, treating missing values as ``None``."""
+    if value is None:
+        return None
+
+    value = value.strip()
+    if not value or value in {"-", "--"}:
+        return None
+
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _extract_currency_code(value: str) -> str | None:
+    normalized = re.sub(r"\s+", "", value)
+    match = re.search(r"\(([A-Z]{3})\)", normalized)
+    return match.group(1) if match else None
+
+
+async def fetch_firstbank_rates() -> list[Rate]:  # noqa: C901
+    """Query First Bank exchange rates."""
+    url = "https://www.firstbank.com.tw/sites/fcb/touch/1565688252532"
+
+    async with httpx.AsyncClient(follow_redirects=True, timeout=_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+    table = soup.find("table")
+    if not table:
+        raise ValueError("No exchange table found on First Bank page")
+
+    rows = table.find_all("tr")
+    if not rows:
+        raise ValueError("No exchange rows found on First Bank page")
+
+    values: dict[str, dict[str, float | None]] = {}
+    for row in rows:
+        cols = [td.get_text(strip=True) for td in row.find_all("td")]
+        if len(cols) < 4:
+            continue
+
+        source = _extract_currency_code(cols[0])
+        if not source:
+            continue
+
+        rate_type = cols[1]
+        buy_rate = _parse_rate(cols[2])
+        sell_rate = _parse_rate(cols[3])
+
+        bucket = values.setdefault(source, {"spot_buy": None, "spot_sell": None, "cash_buy": None, "cash_sell": None})
+
+        if "即期" in rate_type:
+            bucket["spot_buy"] = buy_rate
+            bucket["spot_sell"] = sell_rate
+        elif "現鈔" in rate_type:
+            bucket["cash_buy"] = buy_rate
+            bucket["cash_sell"] = sell_rate
+
+    if not values:
+        raise ValueError("No First Bank rates parsed")
+
+    rates: list[Rate] = []
+    for source, raw in values.items():
+        if all(value is None for value in raw.values()):
+            continue
+
+        rates.append(
+            Rate(
+                exchange=Exchange.FIRSTBANK,
+                source=source,
+                target="TWD",
+                spot_buy=raw["spot_buy"],
+                spot_sell=raw["spot_sell"],
+                cash_buy=raw["cash_buy"],
+                cash_sell=raw["cash_sell"],
+            )
+        )
+
+    if not rates:
+        raise ValueError("No First Bank rates with numeric values parsed")
+
+    return rates

--- a/src/twrate/fetchers/landbank.py
+++ b/src/twrate/fetchers/landbank.py
@@ -1,0 +1,92 @@
+import re
+
+import httpx
+from bs4 import BeautifulSoup
+
+from ..types import Exchange
+from ..types import Rate
+from ._ssl import create_bank_ssl_context
+
+_TIMEOUT = 30
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+}
+
+
+def _parse_rate(value: str | None) -> float | None:
+    """Parse a numeric rate value, treating missing values as ``None``."""
+    if value is None:
+        return None
+
+    value = value.strip()
+    if not value or value in {"-", "--"}:
+        return None
+
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _extract_currency_code(value: str) -> str | None:
+    normalized = re.sub(r"\s+", "", value)
+    match = re.search(r"\(([A-Z]{3})\)", normalized)
+    return match.group(1) if match else None
+
+
+async def fetch_landbank_rates() -> list[Rate]:
+    """Query Land Bank exchange rates."""
+    url = "https://rate.landbank.com.tw/zh-TW/Foreign?mid=35"
+
+    async with httpx.AsyncClient(
+        verify=create_bank_ssl_context(),
+        follow_redirects=True,
+        timeout=_TIMEOUT,
+    ) as client:
+        resp = await client.get(url, headers=_HEADERS)
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+    table = soup.find("table")
+    if not table:
+        raise ValueError("No exchange table found on Land Bank page")
+
+    rates: list[Rate] = []
+    for row in table.find_all("tr"):
+        cols = [td.get_text(strip=True) for td in row.find_all("td")]
+        if len(cols) < 5:
+            continue
+
+        source = _extract_currency_code(cols[0])
+        if not source:
+            continue
+
+        spot_buy = _parse_rate(cols[1])
+        spot_sell = _parse_rate(cols[2])
+        cash_buy = _parse_rate(cols[3])
+        cash_sell = _parse_rate(cols[4])
+
+        if all(value is None for value in (spot_buy, spot_sell, cash_buy, cash_sell)):
+            continue
+
+        rates.append(
+            Rate(
+                exchange=Exchange.LANDBANK,
+                source=source,
+                target="TWD",
+                spot_buy=spot_buy,
+                spot_sell=spot_sell,
+                cash_buy=cash_buy,
+                cash_sell=cash_sell,
+            )
+        )
+
+    if not rates:
+        raise ValueError("No Land Bank rates parsed from page")
+
+    return rates

--- a/src/twrate/fetchers/megabank.py
+++ b/src/twrate/fetchers/megabank.py
@@ -1,0 +1,81 @@
+import httpx
+
+from ..types import Exchange
+from ..types import Rate
+
+_TIMEOUT = 30
+
+
+def _parse_rate(value: str | None) -> float | None:
+    """Parse a numeric rate value, treating missing values as ``None``."""
+    if value is None:
+        return None
+
+    value = value.strip()
+    if not value or value in {"-", "--"}:
+        return None
+
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+async def fetch_megabank_rates() -> list[Rate]:
+    """Query Mega International Commercial Bank exchange rates."""
+    url = "https://www.megabank.com.tw/api/client/ExchangeRate/GetRateData"
+    params = {
+        "sc_lang": "zh-TW",
+        "sc_site": "bank-zh-tw",
+        "dic_lang": "zh-TW",
+    }
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+
+        payload = resp.json()
+
+        rates_data = payload.get("rates")
+        if not isinstance(rates_data, list):
+            raise ValueError("Unexpected response payload from Mega Bank")
+
+        rates: list[Rate] = []
+        for item in rates_data:
+            if not isinstance(item, dict):
+                continue
+
+            curr_key = item.get("currKey", "")
+            if not isinstance(curr_key, str):
+                continue
+
+            source = curr_key.split("|")[0].strip()
+            if not source:
+                continue
+
+            spot = item.get("spot") or {}
+            cash = item.get("cash") or {}
+
+            rate = Rate(
+                exchange=Exchange.MEGABANK,
+                source=source,
+                target="TWD",
+                spot_buy=_parse_rate(spot.get("bid")),
+                spot_sell=_parse_rate(spot.get("ask")),
+                cash_buy=_parse_rate(cash.get("bid")),
+                cash_sell=_parse_rate(cash.get("ask")),
+            )
+            if (
+                rate.spot_buy is None
+                and rate.spot_sell is None
+                and rate.cash_buy is None
+                and rate.cash_sell is None
+            ):
+                continue
+
+            rates.append(rate)
+
+        if not rates:
+            raise ValueError("No Mega Bank rates parsed from API response")
+
+        return rates

--- a/src/twrate/fetchers/yuanta.py
+++ b/src/twrate/fetchers/yuanta.py
@@ -1,0 +1,88 @@
+import re
+
+import httpx
+from bs4 import BeautifulSoup
+
+from ..types import Exchange
+from ..types import Rate
+
+_TIMEOUT = 30
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "zh-TW,zh;q=0.9,en;q=0.8",
+}
+
+
+def _parse_rate(value: str | None) -> float | None:
+    """Parse a numeric rate value, treating missing values as ``None``."""
+    if value is None:
+        return None
+
+    value = value.strip()
+    if not value or value in {"-", "--"}:
+        return None
+
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _extract_currency_code(value: str) -> str | None:
+    normalized = re.sub(r"\s+", "", value)
+    match = re.search(r"\(([A-Z]{3})\)", normalized)
+    return match.group(1) if match else None
+
+
+async def fetch_yuanta_rates() -> list[Rate]:
+    """Query Yuanta Bank exchange rates."""
+    url = "https://www.yuantabank.com.tw/bank/exchangeRate/hostccy.do"
+
+    async with httpx.AsyncClient(follow_redirects=True, timeout=_TIMEOUT) as client:
+        resp = await client.get(url, headers=_HEADERS)
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+    table = soup.find("table")
+    if not table:
+        raise ValueError("No exchange table found on Yuanta Bank page")
+
+    rates: list[Rate] = []
+    for row in table.find_all("tr"):
+        cols = [td.get_text(strip=True) for td in row.find_all("td")]
+        if len(cols) < 5:
+            continue
+
+        source = _extract_currency_code(cols[0])
+        if not source:
+            continue
+
+        spot_buy = _parse_rate(cols[1])
+        spot_sell = _parse_rate(cols[2])
+        cash_buy = _parse_rate(cols[3])
+        cash_sell = _parse_rate(cols[4])
+
+        if all(value is None for value in (spot_buy, spot_sell, cash_buy, cash_sell)):
+            continue
+
+        rates.append(
+            Rate(
+                exchange=Exchange.YUANTA,
+                source=source,
+                target="TWD",
+                spot_buy=spot_buy,
+                spot_sell=spot_sell,
+                cash_buy=cash_buy,
+                cash_sell=cash_sell,
+            )
+        )
+
+    if not rates:
+        raise ValueError("No Yuanta Bank rates parsed from page")
+
+    return rates

--- a/src/twrate/types.py
+++ b/src/twrate/types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from loguru import logger
 from pydantic import BaseModel
@@ -7,7 +7,7 @@ from pydantic import Field
 from pydantic import field_validator
 
 
-class Exchange(str, Enum):
+class Exchange(StrEnum):
     DBS = "DBS_BANK"
     SINOPAC = "BANK_SINOPAC"
     BOT = "BANK_OF_TAIWAN"
@@ -17,6 +17,10 @@ class Exchange(str, Enum):
     NEXT = "NEXT_BANK"
     KGI = "KGI_BANK"
     CATHAY = "CATHAY_BANK"
+    MEGABANK = "MEGA_BANK"
+    FIRSTBANK = "FIRST_BANK"
+    LANDBANK = "LAND_BANK"
+    YUANTA = "YUANTA_BANK"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
## Summary

Added fetcher support for four additional Taiwanese banks requested:
- Mega International Commercial Bank (兆豐)
- First Bank (第一銀行)
- Land Bank (土地銀行)
- Yuanta Bank (元大)

## Details
- Added new fetcher modules:
  - 
  - 
  - 
  - 
- Extended  enum with:
  - , , , 
- Wired dispatch in .
- Updated  supported bank list and TODO completion state.

## Validation
- .............                                                            [100%]
13 passed in 4.10s => all passed (13)
