### PR TITLE
fix: dedupe Taishin rates from nested rate-board tables

### DIFF
--- a/src/twrate/fetchers/taishin.py
+++ b/src/twrate/fetchers/taishin.py
@@ -128,7 +128,10 @@ async def fetch_taishin_rates() -> list[Rate]:
 
         soup = BeautifulSoup(html, "html.parser")
 
-    rates = [rate for table in soup.find_all("table") for rate in _extract_taishin_table_rates(table)]
+    # the rate board nests left/right sub-tables inside an outer table;
+    # parsing nested tables would duplicate every currency
+    tables = [table for table in soup.find_all("table") if table.find_parent("table") is None]
+    rates = [rate for table in tables for rate in _extract_taishin_table_rates(table)]
     if not rates:
         raise ValueError("No Taishin rates parsed from export script")
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -11,6 +11,9 @@ async def test_fetch_rates(exchange: Exchange) -> None:
 
     assert isinstance(rates, list)
     assert len(rates) > 0
+
+    sources = [rate.source for rate in rates]
+    assert len(sources) == len(set(sources)), f"duplicate currencies: {sources}"
     for rate in rates:
         assert rate.exchange == exchange
         assert rate.target == "TWD"


### PR DESCRIPTION
## Summary

`uv run twrate USD` showed 台新銀行 (Taishin Bank) twice. The Taishin rate board nests `left`/`right` sub-tables inside an outer `levelone` table, so iterating every `<table>` in the page parsed the same data twice (once via the outer table, once via the nested `right` table), duplicating every currency.

## Changes

- **`src/twrate/fetchers/taishin.py`**: parse only top-level tables (skip tables that have a `<table>` ancestor). Verified against the live page: 14 unique currencies, same values as before.
- **`tests/test_fetcher.py`**: assert that each fetcher returns unique source currencies, so this class of bug fails the test suite.

## Test plan

- `uv run twrate USD` now shows Taishin once.
- `uv run pytest -k TAISHIN` passes (live test, including the new uniqueness assertion).